### PR TITLE
Parse all args even unknown ones

### DIFF
--- a/camera_simulator/camera_simulator.py
+++ b/camera_simulator/camera_simulator.py
@@ -184,7 +184,7 @@ def main(args=None):
     parser.add_argument('--loop', action='store_true', help='loop video after end')
     parser.set_defaults(loop=False)
 
-    extra_args = parser.parse_args()
+    extra_args, unknown = parser.parse_known_args()
 
     rclpy.init(args=args)
 


### PR DESCRIPTION
At the moment if you pass the parameters in via a launch file you get an unknown parameter error due to additional params being passed in by the launch file. This fix is to allow those additional params but also to just ignore them.